### PR TITLE
Add .browserslistrc configuration

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
+Firefox ESR
+not IE 11


### PR DESCRIPTION
When `ng build` was run, following warning occured:
`Warning: Support was requested for IE 11 in the project's browserslist configuration. IE 11 support is deprecated since Angular v12. For more information, see https://angular.io/guide/browser-support`

Adding .browserslistrc configuration to disable testing with IE 11, as the support is deprecated. 

This PR is part of Hacktoberfest 2021. Requesting hacktoberfest-accepted label if it is feasible.